### PR TITLE
fix: add `workflow_dispatch` event to GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: ${{ vars.HARBOR_REGISTRY }}/${{ vars.HARBOR_NAMESPACE }}/actions-runner-dind


### PR DESCRIPTION
* Add new `workflow_dispatch` event to GitHub build action that enables running workflows manually